### PR TITLE
Change core, to correct include Arduino.h from Arduino core

### DIFF
--- a/boards/custom_atsamd21e17a.json
+++ b/boards/custom_atsamd21e17a.json
@@ -3,7 +3,7 @@
       "arduino": {
           "ldscript": "flash_without_bootloader.ld"
       },
-      "core": "adafruit",
+      "core": "arduino",
       "cpu": "cortex-m0plus",
       "extra_flags": "-DARDUINO_TRINKET_M0 -DCRYSTALLESS -DADAFRUIT_TRINKET_M0 -DARM_MATH_CM0PLUS -D__SAMD21E17A__",
       "f_cpu": "48000000L",


### PR DESCRIPTION
With the current setup PIO wont load the "Arduino.h" and everything else from ...\.platformio\packages\framework-arduino-samd\cores\arduino . 
Instead with Visual Code / PIO forces try to use  ...\.platformio\packages\framework-arduino-samd**-adafruit**\cores\arduino, which dont exists and cant be edited via c_cpp_properties.json file.

Therefor a change to Arduino core is necessery to get the first descripted correct file location